### PR TITLE
新增钉钉webhook推送报告结果

### DIFF
--- a/lounger/utils/webhook.py
+++ b/lounger/utils/webhook.py
@@ -1,0 +1,47 @@
+import base64
+import hashlib
+import hmac
+import time
+import urllib.parse
+
+import requests
+
+
+class DingDingWebhook:
+
+    def __init__(self, webhook_url, secret):
+        '''
+        传入钉钉机器人webhook url以及对应的密钥
+        '''
+        self.timestamp = str(round(time.time() * 1000))
+        self.secret_enc = secret.encode('utf-8')
+        self.string_to_sign_enc = '{}\n{}'.format(self.timestamp, secret).encode('utf-8')
+        self.hmac_code = hmac.new(self.secret_enc, self.string_to_sign_enc, digestmod=hashlib.sha256).digest()
+        self.sign = urllib.parse.quote_plus(base64.b64encode(self.hmac_code))
+        self.webhook_url = f"{webhook_url}&timestamp={self.timestamp}&sign={self.sign}"
+
+    def send_autotest_report(self, result, title='接口自动化测试结果', text=None):
+        if not text:
+            text = f"#### {title} \n  > ###### 用例总数：%s\n > ###### 成功用例数量：%s\n > ###### 失败用例数量：%s\n > ###### 报错用例数量：%s\n > ###### 跳过用例数量：%s \n > ###### 报告生成时间：%s)" % (
+                result._numcollected, len(result.stats.get('passed', [])), len(result.stats.get('failed', [])),
+                len(result.stats.get('error', [])), len(result.stats.get('skipped', [])),
+                time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())))
+        data = {
+            "msgtype": "markdown",
+            "markdown": {
+                "title": "#接口自动化测试报告",
+                "text": text
+            },
+        }
+        res = requests.post(url=self.webhook_url, json=data)
+        # print(res.json())
+
+    def send_msg(self, title, text):
+        data = {
+            "msgtype": 'markdown',
+            "markdown": {
+                "title": title,
+                "text": text
+            }
+        }
+        res = requests.post(url=self.webhook_url, data=data)


### PR DESCRIPTION
使用方法：在对应项目的conftest文件中，新增一个钩子函数获取跑测结果，然后调用send_autotest_report函数，示例：

def pytest_terminal_summary(terminalreporter, exitstatus, config):
    stats = terminalreporter.stats
    total = terminalreporter._numcollected
    passed = len(stats.get("passed", []))
    failed = len(stats.get("failed", []))
    errors = len(stats.get("error", []))
    skipped = len(stats.get("skipped", []))
    terminalreporter.write(
        f"\n总数:{total}  通过:{passed}  失败:{failed}  错误:{errors}  跳过:{skipped}\n"
    )
    # webhook = DingDingWebhook(
    #     webhook_url='https://oapi.dingtalk.com/robot/send?access_token=',
    #     secret='')
    # webhook.send_autotest_report(result=terminalreporter)
