### PR TITLE
fix(web-runner): virtualize streamed logs to prevent browser freezes

### DIFF
--- a/lounger/services/test_execution.py
+++ b/lounger/services/test_execution.py
@@ -16,19 +16,18 @@ import os
 import subprocess
 import sys
 import threading
-import time
 from pathlib import Path
 from typing import Callable
 
 VERBOSITY_FLAGS = {
     "quiet":   ["-q"],
     "normal":  [],
-    "verbose": ["-v", "-s"],
+    "verbose": ["-v"],
     "full":    ["-vv", "-s"],
 }
 
 
-def build_pytest_command(run_id: str, target_file: Path, verbosity: str = "verbose") -> list[str]:
+def build_pytest_command(run_id: str, target_file: Path, verbosity: str = "normal") -> list[str]:
     """
     Build the pytest subprocess command for a run.
 
@@ -36,7 +35,7 @@ def build_pytest_command(run_id: str, target_file: Path, verbosity: str = "verbo
     :param target_file: Path to the ``--run-json`` payload file.
     :param verbosity: quiet | normal | verbose | full.
     """
-    extra = VERBOSITY_FLAGS.get(verbosity, ["-v", "-s"])
+    extra = VERBOSITY_FLAGS.get(verbosity, [])
     return [
         sys.executable, "-m", "pytest",
         "--run-json", str(target_file),
@@ -65,7 +64,7 @@ def start_run(
     scan_dir: str,
     run_id: str,
     nodeids: list[str],
-    verbosity: str = "verbose",
+    verbosity: str = "normal",
     lock: threading.Lock | None = None,
     strip_ansi: Callable[[str], str] | None = None,
 ) -> None:
@@ -94,7 +93,6 @@ def start_run(
             "logs": [],
             "nodeids": nodeids,
             "exit_code": None,
-            "started_at": time.time(),
         }
 
     thread = threading.Thread(
@@ -158,13 +156,12 @@ def _execute_in_thread(
 
     proc.wait()
 
-    summary = f"\n\u2500\u2500 \u6267\u884c\u5b8c\u6210 (exit code: {proc.returncode}) \u2500\u2500\n"
+    summary = f"\n── 执行完成 (exit code: {proc.returncode}) ──\n"
     log_queue.put(summary)
     with lock:
         runs[run_id]["logs"].append(summary)
         runs[run_id]["status"] = "completed"
         runs[run_id]["exit_code"] = proc.returncode
-        runs[run_id]["finished_at"] = time.time()
 
     try:
         target_file.unlink()
@@ -182,8 +179,6 @@ def _serialize_run(info: dict) -> dict:
         "logs": info.get("logs", []),
         "exit_code": info.get("exit_code"),
         "error": info.get("error"),
-        "started_at": info.get("started_at"),
-        "finished_at": info.get("finished_at"),
     }
 
 
@@ -246,70 +241,3 @@ def archive_run(
             runs.pop(old_id, None)
 
         return True
-
-
-# ── run history queries (web runner v2) ───────────────────────────────────
-
-def _runs_dir(scan_dir: str) -> Path:
-    """Return the ``reports/runs/`` directory for a project."""
-    return Path(scan_dir) / "reports" / "runs"
-
-
-def list_archived_runs(scan_dir: str) -> list[dict]:
-    """
-    List all archived run snapshots under ``<scan_dir>/reports/runs/``.
-
-    Returns a list of summary dicts sorted by modification time (newest first).
-    Each summary contains: run_id, status, exit_code, case_count,
-    started_at, finished_at.
-    """
-    runs_dir = _runs_dir(scan_dir)
-    if not runs_dir.is_dir():
-        return []
-
-    results: list[dict] = []
-    for fp in sorted(runs_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
-        try:
-            data = json.loads(fp.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        results.append({
-            "run_id": fp.stem,
-            "status": data.get("status"),
-            "exit_code": data.get("exit_code"),
-            "case_count": len(data.get("nodeids", [])),
-            "started_at": data.get("started_at"),
-            "finished_at": data.get("finished_at"),
-        })
-    return results
-
-
-def load_archived_run(scan_dir: str, run_id: str) -> dict | None:
-    """
-    Load a single archived run's full data (including logs).
-
-    :return: The run snapshot dict, or None if not found.
-    """
-    fp = _runs_dir(scan_dir) / f"{run_id}.json"
-    if not fp.is_file():
-        return None
-    try:
-        return json.loads(fp.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-
-
-def delete_archived_run(scan_dir: str, run_id: str) -> bool:
-    """
-    Delete an archived run file.
-
-    :return: True if the file was deleted, False if not found.
-    """
-    fp = _runs_dir(scan_dir) / f"{run_id}.json"
-    if not fp.is_file():
-        return False
-    try:
-        fp.unlink()
-        return True
-    except OSError:
-        return False

--- a/lounger/web_runner/html.py
+++ b/lounger/web_runner/html.py
@@ -6,7 +6,6 @@ _FALLBACK_HTML = r"""<!DOCTYPE html>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>lounger Test Runner</title>
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNiIgZmlsbD0iIzFlMWUyZSIvPgogIDxwYXRoIGQ9Ik0xMiA2aDh2MmgtMXYxMGwzIDcuNWMuNCAxLS4yIDIuMi0xLjMgMi41aC05LjRjLTEuMS0uMy0xLjctMS41LTEuMy0yLjVMMTMgMThWOGgtMVY2eiIgZmlsbD0iIzg5YjRmYSIgb3BhY2l0eT0iMC45Ii8+CiAgPGVsbGlwc2UgY3g9IjE2IiBjeT0iMjQiIHJ4PSI0IiByeT0iMiIgZmlsbD0iI2E2ZTNhMSIgb3BhY2l0eT0iMC42Ii8+CiAgPGNpcmNsZSBjeD0iMTQuNSIgY3k9IjIyIiByPSIwLjgiIGZpbGw9IiNhNmUzYTEiIG9wYWNpdHk9IjAuOCIvPgogIDxjaXJjbGUgY3g9IjE3IiBjeT0iMjMuNSIgcj0iMC41IiBmaWxsPSIjYTZlM2ExIiBvcGFjaXR5PSIwLjciLz4KPC9zdmc+">
 <style>
 :root {
   --bg: #1e1e2e; --surface: #282840; --border: #3a3a5c;
@@ -27,7 +26,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 .sidebar-resizer:hover::after, .sidebar-resizer.dragging::after { background: var(--accent); }
 .sidebar-header { padding: 16px; border-bottom: 1px solid var(--border);
   display: flex; align-items: center; gap: 10px; }
-.sidebar-header h1 { font-size: 18px; font-weight: 600; flex: 1; }
+.sidebar-header h1 { font-size: 18px; font-weight: 600; }
 .logo { font-size: 24px; }
 .toolbar { padding: 10px 16px; display: flex; gap: 8px; flex-wrap: wrap;
   border-bottom: 1px solid var(--border); }
@@ -41,21 +40,8 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 .btn-accent { background: var(--accent); color: var(--bg); }
 .btn-green { background: var(--green); color: var(--bg); }
 .btn-outline { background: transparent; border: 1px solid var(--border); color: var(--text); }
-.btn-sm { padding: 3px 8px; font-size: 11px; }
-.btn-danger { background: var(--red); color: var(--bg); }
-/* ── tag chips ── */
-.tag-bar { padding: 6px 16px; border-bottom: 1px solid var(--border); display: flex;
-  gap: 4px; flex-wrap: wrap; align-items: center; min-height: 32px; }
-.tag-bar:empty { display: none; }
-.tag-chip { padding: 2px 8px; border-radius: 12px; font-size: 11px; cursor: pointer;
-  border: 1px solid var(--border); color: var(--muted); background: transparent;
-  transition: all .15s; user-select: none; }
-.tag-chip:hover { border-color: var(--accent); color: var(--text); }
-.tag-chip.active { background: var(--accent); color: var(--bg); border-color: var(--accent); }
-.tag-chip.fav-chip { border-color: var(--yellow); color: var(--yellow); }
-.tag-chip.fav-chip.active { background: var(--yellow); color: var(--bg); }
-/* ── tree nodes ── */
 .case-list { flex: 1; overflow-x: hidden; overflow-y: auto; padding: 4px 0; }
+/* ── tree nodes ── */
 .tree-node { display: flex; align-items: center; gap: 6px; cursor: pointer;
   user-select: none; font-size: 13px; border-left: 3px solid transparent;
   min-height: 30px; padding-right: 10px; }
@@ -80,12 +66,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   color: var(--bg); border: none; border-radius: 4px; cursor: pointer; opacity: 0;
   flex-shrink: 0; }
 .tree-node:hover .run-btn { opacity: 1; }
-.fav-btn { padding: 2px 6px; font-size: 12px; background: transparent; border: none;
-  cursor: pointer; opacity: 0.4; flex-shrink: 0; transition: opacity .15s; }
-.fav-btn:hover { opacity: 0.8; }
-.fav-btn.is-fav { opacity: 1; color: var(--yellow); }
-.tree-node:hover .fav-btn { opacity: 0.7; }
-.tree-node .fav-btn.is-fav { opacity: 1; }
 .empty-state { padding: 40px 20px; text-align: center; color: var(--muted); }
 /* ── main ── */
 .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
@@ -96,49 +76,18 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
 .status-dot.done { background: var(--green); }
 .status-dot.error { background: var(--red); }
 @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
-/* ── tabs ── */
-.tab-bar { display: flex; gap: 0; border-bottom: 1px solid var(--border); padding: 0 20px; }
-.tab-btn { padding: 8px 16px; font-size: 13px; cursor: pointer; background: transparent;
-  border: none; border-bottom: 2px solid transparent; color: var(--muted);
-  transition: all .15s; }
-.tab-btn:hover { color: var(--text); }
-.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
-.tab-panel { display: none; flex: 1; overflow: hidden; flex-direction: column; }
-.tab-panel.active { display: flex; }
-/* ── history ── */
-.history-list { padding: 16px 20px; overflow-y: auto; flex: 1; }
-.history-item { display: flex; align-items: center; gap: 12px; padding: 10px 14px;
-  border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 8px;
-  cursor: pointer; transition: background .15s; }
-.history-item:hover { background: rgba(255,255,255,.03); }
-.history-item .h-status { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
-.history-item .h-status.pass { background: var(--green); }
-.history-item .h-status.fail { background: var(--red); }
-.history-item .h-info { flex: 1; }
-.history-item .h-id { font-weight: 500; font-size: 13px; }
-.history-item .h-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
-.history-item .h-actions { display: flex; gap: 6px; }
-.history-detail { padding: 0; flex: 1; overflow: hidden; display: flex; flex-direction: column; }
-.history-detail-header { padding: 12px 20px; border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; gap: 12px; }
-/* ── log ── */
-.log-container { flex: 1; overflow-y: auto; padding: 16px 20px;
+.log-container { flex: 1; overflow: auto; position: relative;
   background: #11111b; font-family: "SF Mono", "Fira Code", monospace;
-  font-size: 13px; line-height: 1.6; white-space: pre-wrap; word-break: break-all; }
-.log-line { }
+  font-size: 13px; line-height: 21px; }
+.log-spacer { width: 1px; opacity: 0; }
+.log-viewport { position: absolute; top: 0; left: 0; right: 0; }
+.log-line { height: 21px; line-height: 21px; padding: 0 20px; white-space: pre; overflow: hidden; }
 .log-line.pass { color: var(--green); }
 .log-line.fail { color: var(--red); }
 .log-line.warn { color: var(--yellow); }
 .log-line.summary { color: var(--accent); font-weight: bold; }
 .log-placeholder { color: var(--muted); text-align: center; padding: 60px 20px; }
 .log-placeholder .icon { font-size: 48px; margin-bottom: 12px; }
-/* ── scrollbar ── */
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(108,112,134,.35); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(108,112,134,.55); }
-::-webkit-scrollbar-corner { background: transparent; }
-* { scrollbar-width: thin; scrollbar-color: rgba(108,112,134,.35) transparent; }
 </style>
 </head>
 <body>
@@ -159,11 +108,9 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
       <button class="btn btn-outline" onclick="deselectAll()">取消</button>
     </div>
     <div class="toolbar">
-      <button class="btn btn-green" onclick="runSelected()" id="runSelectedBtn" style="flex:1">▶ 执行选中</button>
-      <button class="btn btn-accent" onclick="runAll()" id="runAllBtn" style="flex:1">▶▶ 执行全部</button>
+      <button class="btn btn-green" onclick="runSelected()" style="flex:1">▶ 执行选中</button>
+      <button class="btn btn-accent" onclick="runAll()" style="flex:1">▶▶ 执行全部</button>
     </div>
-    <!-- tag filter bar -->
-    <div class="tag-bar" id="tagBar"></div>
     <div class="case-list" id="caseList">
       <div class="empty-state">⏳ 正在收集用例...</div>
     </div>
@@ -175,50 +122,23 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   <div class="main-header">
     <span class="status-dot" id="statusDot"></span>
     <span id="statusText">就绪</span>
-    <span id="runCounter" style="font-size:12px;color:var(--muted)"></span>
     <span style="flex:1"></span>
     <span id="verbosityGroup" style="display:flex;align-items:center;gap:2px;font-size:12px;color:var(--muted)">
       <label style="cursor:pointer"><input type="radio" name="verbosity" value="quiet" onclick="setVerbosity('quiet')"> 静默</label>
-      <label style="cursor:pointer;margin-left:6px"><input type="radio" name="verbosity" value="normal" onclick="setVerbosity('normal')"> 标准</label>
-      <label style="cursor:pointer;margin-left:6px"><input type="radio" name="verbosity" value="verbose" onclick="setVerbosity('verbose')" checked> 详细</label>
+      <label style="cursor:pointer;margin-left:6px"><input type="radio" name="verbosity" value="normal" onclick="setVerbosity('normal')" checked> 标准</label>
+      <label style="cursor:pointer;margin-left:6px"><input type="radio" name="verbosity" value="verbose" onclick="setVerbosity('verbose')"> 详细</label>
       <label style="cursor:pointer;margin-left:6px"><input type="radio" name="verbosity" value="full" onclick="setVerbosity('full')"> 完整</label>
     </span>
     <button class="btn btn-outline" onclick="copyLogs()" id="copyBtn" style="display:none">📋 复制日志</button>
     <button class="btn btn-outline" onclick="clearLogs()" id="clearBtn" style="display:none">🧹 清空日志</button>
   </div>
-  <!-- tab bar -->
-  <div class="tab-bar">
-    <button class="tab-btn active" onclick="switchTab('live')" id="tabLive">📺 实时日志</button>
-    <button class="tab-btn" onclick="switchTab('history')" id="tabHistory">📜 历史记录</button>
-  </div>
-  <!-- live log panel -->
-  <div class="tab-panel active" id="panelLive">
-    <div class="log-container" id="logContainer">
+  <div class="log-container" id="logContainer" onscroll="scheduleVirtualLogRender()">
+    <div class="log-spacer" id="logSpacer"></div>
+    <div class="log-viewport" id="logViewport">
       <div class="log-placeholder">
-        <div class="icon">📋</div>
-        <div>选择左侧用例，点击「执行」开始</div>
+      <div class="icon">📋</div>
+      <div>选择左侧用例，点击「执行」开始</div>
       </div>
-    </div>
-  </div>
-  <!-- history panel -->
-  <div class="tab-panel" id="panelHistory">
-    <div class="history-list" id="historyList">
-      <div class="log-placeholder">
-        <div class="icon">📜</div>
-        <div>暂无历史记录</div>
-      </div>
-    </div>
-  </div>
-  <!-- history detail panel -->
-  <div class="tab-panel" id="panelHistoryDetail">
-    <div class="history-detail">
-      <div class="history-detail-header">
-        <button class="btn btn-outline btn-sm" onclick="backToHistory()">← 返回列表</button>
-        <span id="historyDetailTitle" style="font-weight:500"></span>
-        <span style="flex:1"></span>
-        <button class="btn btn-outline btn-sm" onclick="copyHistoryLogs()" id="copyHistoryBtn">📋 复制</button>
-      </div>
-      <div class="log-container" id="historyLogContainer"></div>
     </div>
   </div>
 </div>
@@ -230,57 +150,65 @@ let caseTree = null;
 let selectedIds = new Set();
 let currentRunId = null;
 let eventSource = null;
-let currentVerbosity = 'verbose';
+let currentVerbosity = 'normal';
 function setVerbosity(v) { currentVerbosity = v; }
 let lastRunIds = new Set();
+const LOG_LINE_HEIGHT = 21;
+const LOG_OVERSCAN = 60;
+let pendingLogLines = [];
+let allLogLines = [];
+let followLogEnd = true;
+let logFlushFrame = null;
+let virtualLogRenderFrame = null;
 const EXPANDED_NODES_KEY = 'lounger.webRunner.expandedNodes';
 const SIDEBAR_WIDTH_KEY = 'lounger.webRunner.sidebarWidth';
-const FAVORITES_KEY = 'lounger.webRunner.favorites';
 let expandedNodes = loadExpandedNodes();
-let favorites = loadFavorites();
-let activeTagFilters = new Set();
-let showFavoritesOnly = false;
 
-// ── localStorage helpers ──
 function loadExpandedNodes() {
   try {
     const raw = localStorage.getItem(EXPANDED_NODES_KEY);
     if (!raw) return new Set();
     const parsed = JSON.parse(raw);
     return new Set(Array.isArray(parsed) ? parsed : []);
-  } catch(_) { return new Set(); }
+  } catch(_) {
+    return new Set();
+  }
 }
+
 function saveExpandedNodes() {
-  try { localStorage.setItem(EXPANDED_NODES_KEY, JSON.stringify([...expandedNodes])); } catch(_) {}
-}
-function loadSidebarWidth() {
-  try { return localStorage.getItem(SIDEBAR_WIDTH_KEY); } catch(_) { return null; }
-}
-function saveSidebarWidth(width) {
-  try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width)); } catch(_) {}
-}
-function loadFavorites() {
   try {
-    const raw = localStorage.getItem(FAVORITES_KEY);
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw);
-    return new Set(Array.isArray(parsed) ? parsed : []);
-  } catch(_) { return new Set(); }
+    localStorage.setItem(EXPANDED_NODES_KEY, JSON.stringify([...expandedNodes]));
+  } catch(_) {}
 }
-function saveFavorites() {
-  try { localStorage.setItem(FAVORITES_KEY, JSON.stringify([...favorites])); } catch(_) {}
+
+function loadSidebarWidth() {
+  try {
+    return localStorage.getItem(SIDEBAR_WIDTH_KEY);
+  } catch(_) {
+    return null;
+  }
 }
+
+function saveSidebarWidth(width) {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  } catch(_) {}
+}
+
 function applySidebarWidth(width) {
   const shell = document.getElementById('sidebarShell');
   if (!shell || !width) return;
   shell.style.width = width + 'px';
 }
+
 function startSidebarResize(event) {
   event.preventDefault();
   const shell = document.getElementById('sidebarShell');
   const resizer = document.getElementById('sidebarResizer');
   if (!shell || !resizer) return;
+
   resizer.classList.add('dragging');
+
   function onMove(ev) {
     const minWidth = 280;
     const maxWidth = Math.min(window.innerWidth * 0.7, 900);
@@ -288,118 +216,15 @@ function startSidebarResize(event) {
     shell.style.width = nextWidth + 'px';
     saveSidebarWidth(nextWidth);
   }
+
   function onUp() {
     resizer.classList.remove('dragging');
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
   }
+
   document.addEventListener('mousemove', onMove);
   document.addEventListener('mouseup', onUp);
-}
-
-// ── tabs ──
-function switchTab(tab) {
-  document.getElementById('tabLive').classList.toggle('active', tab === 'live');
-  document.getElementById('tabHistory').classList.toggle('active', tab === 'history');
-  document.getElementById('panelLive').classList.toggle('active', tab === 'live');
-  document.getElementById('panelHistory').classList.toggle('active', tab === 'history');
-  document.getElementById('panelHistoryDetail').classList.remove('active');
-  if (tab === 'history') loadHistory();
-}
-function showHistoryDetail() {
-  document.getElementById('panelHistory').classList.remove('active');
-  document.getElementById('panelHistoryDetail').classList.add('active');
-}
-function backToHistory() {
-  document.getElementById('panelHistoryDetail').classList.remove('active');
-  document.getElementById('panelHistory').classList.add('active');
-}
-
-// ── history ──
-async function loadHistory() {
-  const container = document.getElementById('historyList');
-  try {
-    const resp = await fetch('/api/history');
-    const runs = await resp.json();
-    if (!runs.length) {
-      container.innerHTML = '<div class="log-placeholder"><div class="icon">📜</div><div>暂无历史记录</div></div>';
-      return;
-    }
-    let html = '';
-    for (const r of runs) {
-      const statusClass = r.exit_code === 0 ? 'pass' : 'fail';
-      const statusText = r.exit_code === 0 ? '通过' : '失败';
-      const timeStr = r.finished_at ? formatTime(r.finished_at) : (r.started_at ? formatTime(r.started_at) : '未知');
-      const duration = (r.started_at && r.finished_at) ? formatDuration(r.finished_at - r.started_at) : '';
-      html += '<div class="history-item" onclick="viewHistoryRun(\'' + esc(r.run_id) + '\')">';
-      html += '<div class="h-status ' + statusClass + '"></div>';
-      html += '<div class="h-info">';
-      html += '<div class="h-id">' + esc(r.run_id) + ' <span style="font-size:11px;color:var(--muted)">' + statusText + '</span></div>';
-      html += '<div class="h-meta">' + r.case_count + ' 用例';
-      if (duration) html += ' · ' + duration;
-      html += ' · ' + timeStr + '</div>';
-      html += '</div>';
-      html += '<div class="h-actions">';
-      html += '<button class="btn btn-danger btn-sm" onclick="event.stopPropagation(); deleteHistoryRun(\'' + esc(r.run_id) + '\')">删除</button>';
-      html += '</div></div>';
-    }
-    container.innerHTML = html;
-  } catch(e) {
-    container.innerHTML = '<div class="log-placeholder"><div class="icon">❌</div><div>加载失败: ' + esc(e.message) + '</div></div>';
-  }
-}
-
-async function viewHistoryRun(runId) {
-  try {
-    const resp = await fetch('/api/history/' + runId);
-    if (!resp.ok) { alert('未找到该运行记录'); return; }
-    const data = await resp.json();
-    document.getElementById('historyDetailTitle').textContent = runId + ' — ' + (data.exit_code === 0 ? '全部通过 ✅' : '执行失败 ❌');
-    const logEl = document.getElementById('historyLogContainer');
-    logEl.innerHTML = '';
-    const logs = data.logs || [];
-    for (const line of logs) {
-      const div = document.createElement('div');
-      div.className = 'log-line';
-      if (line.includes('PASSED')) div.classList.add('pass');
-      else if (line.includes('FAILED') || line.includes('ERROR')) div.classList.add('fail');
-      else if (line.includes('WARNING') || line.includes('skipped')) div.classList.add('warn');
-      else if (line.startsWith('──')) div.classList.add('summary');
-      div.textContent = line;
-      logEl.appendChild(div);
-    }
-    logEl.scrollTop = logEl.scrollHeight;
-    showHistoryDetail();
-  } catch(e) {
-    alert('加载失败: ' + e.message);
-  }
-}
-
-async function deleteHistoryRun(runId) {
-  if (!confirm('确定要删除此历史记录吗？')) return;
-  try {
-    await fetch('/api/history/' + runId, { method: 'DELETE' });
-    loadHistory();
-  } catch(e) {
-    alert('删除失败: ' + e.message);
-  }
-}
-
-function copyHistoryLogs() {
-  const el = document.getElementById('historyLogContainer');
-  navigator.clipboard.writeText(el.innerText || '').catch(() => {});
-}
-
-function formatTime(ts) {
-  const d = new Date(ts * 1000);
-  return d.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' });
-}
-function formatDuration(seconds) {
-  if (seconds < 1) return '< 1s';
-  if (seconds < 60) return Math.round(seconds) + 's';
-  const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds % 60);
-  return m + 'm ' + s + 's';
 }
 
 // ── fetch cases ──
@@ -413,7 +238,6 @@ async function loadCases() {
     const treeData = await treeResp.json();
     caseTree = treeData.tree;
     renderTree();
-    renderTagBar();
   } catch(e) {
     document.getElementById('caseList').innerHTML =
       '<div class="empty-state">❌ 加载失败: ' + e.message + '</div>';
@@ -431,47 +255,6 @@ function updateStats() {
   stats.innerHTML = '📊 共 <b>' + allCases.length + '</b> 用例 &nbsp;|&nbsp; pytest: <b>' + pytest + '</b> &nbsp;|&nbsp; YAML: <b>' + yaml + '</b>';
 }
 
-// ── tag bar ──
-function renderTagBar() {
-  const bar = document.getElementById('tagBar');
-  const allMarks = new Set();
-  for (const c of allCases) {
-    const marks = c.markers || c.marks || [];
-    for (const m of marks) allMarks.add(m);
-  }
-  let html = '';
-  // favorites toggle
-  html += '<span class="tag-chip fav-chip' + (showFavoritesOnly ? ' active' : '') + '" onclick="toggleFavoritesFilter()">⭐ 收藏</span>';
-  for (const tag of [...allMarks].sort()) {
-    const active = activeTagFilters.has(tag) ? ' active' : '';
-    html += '<span class="tag-chip' + active + '" onclick="toggleTagFilter(\'' + esc(tag) + '\')">' + esc(tag) + '</span>';
-  }
-  bar.innerHTML = html;
-}
-
-function toggleTagFilter(tag) {
-  if (activeTagFilters.has(tag)) activeTagFilters.delete(tag);
-  else activeTagFilters.add(tag);
-  renderTagBar();
-  filterCases();
-}
-
-function toggleFavoritesFilter() {
-  showFavoritesOnly = !showFavoritesOnly;
-  renderTagBar();
-  filterCases();
-}
-
-function toggleFavorite(nodeid, ev) {
-  ev.stopPropagation();
-  if (favorites.has(nodeid)) favorites.delete(nodeid);
-  else favorites.add(nodeid);
-  saveFavorites();
-  renderTree();
-  renderTagBar();
-}
-
-// ── tree rendering ──
 function renderTree() {
   const container = document.getElementById('caseList');
   if (!allCases.length) {
@@ -487,7 +270,7 @@ function renderTree() {
   }
   container.innerHTML = html;
   updateStats();
-  if (document.getElementById('search').value || activeTagFilters.size > 0 || showFavoritesOnly) {
+  if (document.getElementById('search').value) {
     filterCases();
   }
 }
@@ -542,7 +325,6 @@ function renderCaseNode(c, depth) {
   const sel = selectedIds.has(c.nodeid) ? ' selected' : '';
   const runFlag = lastRunIds.has(c.nodeid) ? ' just-run' : '';
   const checked = selectedIds.has(c.nodeid) ? ' checked' : '';
-  const isFav = favorites.has(c.nodeid);
   const desc = c.description ? c.description.trim() : '';
   const titleParts = [c.name];
   if (c.nodeid) titleParts.push(c.nodeid);
@@ -554,7 +336,6 @@ function renderCaseNode(c, depth) {
   html += '<span class="tree-toggle leaf">▶</span>';
   html += '<input type="checkbox" ' + checked + ' onclick="event.stopPropagation(); toggleCase(\'' + esc(c.nodeid) + '\', event)">';
   html += '<span class="tree-label" title="' + esc(tooltip) + '">🧪 ' + esc(c.name) + '</span>';
-  html += '<button class="fav-btn' + (isFav ? ' is-fav' : '') + '" onclick="toggleFavorite(\'' + esc(c.nodeid) + '\', event)" title="' + (isFav ? '取消收藏' : '收藏') + '">' + (isFav ? '⭐' : '☆') + '</button>';
   html += '<button class="run-btn" onclick="event.stopPropagation(); runSingle(\'' + esc(c.nodeid) + '\')">▶</button>';
   html += '</div>';
   return html;
@@ -579,8 +360,11 @@ function toggleTreeNode(el) {
 }
 
 function toggleCase(nodeid, ev) {
-  if (selectedIds.has(nodeid)) selectedIds.delete(nodeid);
-  else selectedIds.add(nodeid);
+  if (selectedIds.has(nodeid)) {
+    selectedIds.delete(nodeid);
+  } else {
+    selectedIds.add(nodeid);
+  }
   const row = ev.target.closest('.tree-node');
   if (row) {
     const cb = row.querySelector('input[type=checkbox]');
@@ -598,46 +382,16 @@ function deselectAll() {
   renderTree();
 }
 
-function caseMatchesFilters(c) {
-  // favorites filter
-  if (showFavoritesOnly && !favorites.has(c.nodeid)) return false;
-  // tag filter (OR logic: case must have at least one active tag)
-  if (activeTagFilters.size > 0) {
-    const marks = new Set(c.markers || c.marks || []);
-    let hasMatch = false;
-    for (const t of activeTagFilters) {
-      if (marks.has(t)) { hasMatch = true; break; }
-    }
-    if (!hasMatch) return false;
-  }
-  return true;
-}
-
 function filterCases() {
   const q = document.getElementById('search').value.toLowerCase();
   const container = document.getElementById('caseList');
   const allRows = container.querySelectorAll('.tree-node');
   const allGroups = container.querySelectorAll('.tree-children');
 
-  // build a set of case nodeids that pass filters
-  const visibleNodeids = new Set();
-  for (const c of allCases) {
-    const label = (c.name || '').toLowerCase();
-    const textMatch = !q || label.includes(q);
-    if (textMatch && caseMatchesFilters(c)) {
-      visibleNodeids.add(c.nodeid);
-    }
-  }
-
-  const hasFilters = q || activeTagFilters.size > 0 || showFavoritesOnly;
-
   allRows.forEach(row => {
     if (row.classList.contains('tree-case')) {
-      // extract nodeid from the onclick handler
-      const onclickAttr = row.getAttribute('onclick') || '';
-      const m = onclickAttr.match(/toggleCase\('([^']+)'/);
-      const nid = m ? m[1] : '';
-      row.style.display = (!hasFilters || visibleNodeids.has(nid)) ? '' : 'none';
+      const label = (row.querySelector('.tree-label')?.textContent || '').toLowerCase();
+      row.style.display = (!q || label.includes(q)) ? '' : 'none';
     }
   });
 
@@ -660,7 +414,7 @@ function filterCases() {
         header.classList.add('open');
         header.style.display = '';
       }
-    } else if (hasFilters) {
+    } else if (q) {
       group.style.display = 'none';
       group.classList.remove('show');
     } else {
@@ -675,7 +429,7 @@ function filterCases() {
     }
   });
 
-  if (hasFilters) {
+  if (q) {
     allRows.forEach(row => {
       if (!row.classList.contains('tree-case')) {
         const next = row.nextElementSibling;
@@ -714,10 +468,76 @@ async function runSingle(nodeid) {
 }
 
 function runFile(nodeidsStr) {
+  // data-ids carries encodeURIComponent(JSON.stringify(...)) so quotes in
+  // nodeids cannot break the HTML attribute (3.8 §4)
   const ids = JSON.parse(decodeURIComponent(nodeidsStr));
   for (const nid of ids) lastRunIds.add(nid);
   renderTree();
   startRun(ids);
+}
+
+function queueLogLines(lines) {
+  if (!lines.length) return;
+  pendingLogLines.push(...lines);
+  if (logFlushFrame === null) {
+    logFlushFrame = requestAnimationFrame(flushLogLines);
+  }
+}
+
+function flushLogLines() {
+  logFlushFrame = null;
+  if (!pendingLogLines.length) return;
+
+  allLogLines.push(...pendingLogLines.splice(0, pendingLogLines.length));
+  renderVirtualLogs();
+  if (followLogEnd) {
+    const logEl = document.getElementById('logContainer');
+    logEl.scrollTop = logEl.scrollHeight;
+    renderVirtualLogs();
+  }
+}
+
+function scheduleVirtualLogRender() {
+  const logEl = document.getElementById('logContainer');
+  followLogEnd = logEl.scrollTop + logEl.clientHeight >= logEl.scrollHeight - 24;
+  if (virtualLogRenderFrame === null) {
+    virtualLogRenderFrame = requestAnimationFrame(renderVirtualLogs);
+  }
+}
+
+function renderVirtualLogs() {
+  virtualLogRenderFrame = null;
+  const logEl = document.getElementById('logContainer');
+  const spacer = document.getElementById('logSpacer');
+  const viewport = document.getElementById('logViewport');
+
+  if (!allLogLines.length) {
+    spacer.style.height = '0px';
+    viewport.style.transform = 'translateY(0px)';
+    viewport.innerHTML = '<div class="log-placeholder"><div class="icon">📋</div><div>选择左侧用例，点击「执行」开始</div></div>';
+    return;
+  }
+
+  const visibleRows = Math.ceil(logEl.clientHeight / LOG_LINE_HEIGHT);
+  const start = Math.max(0, Math.floor(logEl.scrollTop / LOG_LINE_HEIGHT) - LOG_OVERSCAN);
+  const end = Math.min(allLogLines.length, start + visibleRows + LOG_OVERSCAN * 2);
+  const fragment = document.createDocumentFragment();
+
+  for (let index = start; index < end; index++) {
+    const line = allLogLines[index];
+    const div = document.createElement('div');
+    div.className = 'log-line';
+    if (line.includes('PASSED')) div.classList.add('pass');
+    else if (line.includes('FAILED') || line.includes('ERROR')) div.classList.add('fail');
+    else if (line.includes('WARNING') || line.includes('skipped')) div.classList.add('warn');
+    else if (line.startsWith('──')) div.classList.add('summary');
+    div.textContent = line;
+    fragment.appendChild(div);
+  }
+
+  spacer.style.height = (allLogLines.length * LOG_LINE_HEIGHT) + 'px';
+  viewport.style.transform = 'translateY(' + (start * LOG_LINE_HEIGHT) + 'px)';
+  viewport.replaceChildren(fragment);
 }
 
 async function startRun(nodeids) {
@@ -732,8 +552,6 @@ async function startRun(nodeids) {
   if (data.error) { alert(data.error); return; }
 
   currentRunId = data.run_id;
-  setRunButtonsDisabled(true);
-  switchTab('live');
   document.getElementById('statusDot').className = 'status-dot running';
   document.getElementById('statusText').textContent = '运行中 (' + data.count + ' 用例)';
   document.getElementById('copyBtn').style.display = '';
@@ -741,31 +559,20 @@ async function startRun(nodeids) {
   clearLogs();
 
   eventSource = new EventSource('/api/stream/' + data.run_id);
-  const logEl = document.getElementById('logContainer');
 
   eventSource.onmessage = function(ev) {
     const msg = JSON.parse(ev.data);
     if (msg.heartbeat) return;
-    if (msg.line) {
-      const div = document.createElement('div');
-      div.className = 'log-line';
-      if (msg.line.includes('PASSED')) div.classList.add('pass');
-      else if (msg.line.includes('FAILED') || msg.line.includes('ERROR')) div.classList.add('fail');
-      else if (msg.line.includes('WARNING') || msg.line.includes('skipped')) div.classList.add('warn');
-      else if (msg.line.startsWith('──')) div.classList.add('summary');
-      div.textContent = msg.line;
-      logEl.appendChild(div);
-      logEl.scrollTop = logEl.scrollHeight;
-    }
+    const lines = Array.isArray(msg.lines) ? msg.lines : (msg.line ? [msg.line] : []);
+    queueLogLines(lines);
     if (msg.done) {
+      flushLogLines();
       eventSource.close();
       eventSource = null;
       document.getElementById('statusDot').className = 'status-dot ' +
         (msg.exit_code === 0 ? 'done' : 'error');
       document.getElementById('statusText').textContent =
         msg.exit_code === 0 ? '全部通过 ✅' : '执行失败 ❌ (exit ' + msg.exit_code + ')';
-      setRunButtonsDisabled(false);
-      updateRunStatus();
       loadCases();
     }
   };
@@ -773,43 +580,20 @@ async function startRun(nodeids) {
   eventSource.onerror = function() {
     if (eventSource && eventSource.readyState === EventSource.CLOSED) {
       eventSource = null;
-      setRunButtonsDisabled(false);
-      updateRunStatus();
     }
   };
 }
 
-function setRunButtonsDisabled(disabled) {
-  const btn1 = document.getElementById('runSelectedBtn');
-  const btn2 = document.getElementById('runAllBtn');
-  if (btn1) { btn1.disabled = disabled; btn1.style.opacity = disabled ? '0.5' : '1'; }
-  if (btn2) { btn2.disabled = disabled; btn2.style.opacity = disabled ? '0.5' : '1'; }
-}
-
-async function updateRunStatus() {
-  try {
-    const resp = await fetch('/api/runs');
-    const data = await resp.json();
-    const counter = document.getElementById('runCounter');
-    if (data.running) {
-      counter.textContent = '🏃 运行中';
-      counter.style.color = 'var(--yellow)';
-    } else {
-      counter.textContent = '✅ 就绪';
-      counter.style.color = 'var(--muted)';
-    }
-  } catch(_) {}
-}
-
 function copyLogs() {
   const el = document.getElementById('logContainer');
-  const text = el.innerText || '';
+  const text = allLogLines.join('') || el.innerText || '';
   navigator.clipboard.writeText(text).then(() => {
     const btn = document.getElementById('copyBtn');
     const orig = btn.textContent;
     btn.textContent = '✅ 已复制';
     setTimeout(() => { btn.textContent = orig; }, 1500);
   }).catch(() => {
+    // fallback for older browsers or non-HTTPS
     const ta = document.createElement('textarea');
     ta.value = text;
     ta.style.position = 'fixed'; ta.style.opacity = '0';
@@ -825,7 +609,18 @@ function copyLogs() {
 }
 
 function clearLogs() {
-  document.getElementById('logContainer').innerHTML = '';
+  pendingLogLines = [];
+  allLogLines = [];
+  followLogEnd = true;
+  if (logFlushFrame !== null) {
+    cancelAnimationFrame(logFlushFrame);
+    logFlushFrame = null;
+  }
+  if (virtualLogRenderFrame !== null) {
+    cancelAnimationFrame(virtualLogRenderFrame);
+    virtualLogRenderFrame = null;
+  }
+  renderVirtualLogs();
 }
 
 async function refreshCases() {
@@ -846,7 +641,6 @@ function esc(s) { return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').repl
 
 applySidebarWidth(loadSidebarWidth());
 loadCases();
-updateRunStatus();
 </script>
 </body>
 </html>"""

--- a/lounger/web_runner/server.py
+++ b/lounger/web_runner/server.py
@@ -7,12 +7,6 @@ import threading
 import uuid
 from urllib.parse import urlparse
 
-from lounger.services.test_execution import (
-    delete_archived_run,
-    list_archived_runs,
-    load_archived_run,
-)
-
 from . import state
 from .collect import get_test_cases
 from .executor import _execute_tests, archive_finished_runs
@@ -22,6 +16,7 @@ from .tree import _build_case_tree
 
 # HTML page cache (module-local)
 _HTML_PAGE: str | None = None
+_SSE_BATCH_LINES = 64
 
 
 def _load_html() -> str:
@@ -56,11 +51,6 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
             self._serve_json({"tree": tree, "flat": cases})
         elif path == "/api/runs":
             self._serve_runs()
-        elif path == "/api/history":
-            self._serve_history_list()
-        elif path.startswith("/api/history/"):
-            run_id = path.split("/")[-1]
-            self._serve_history_detail(run_id)
         elif path.startswith("/api/stream/"):
             self._serve_stream(path.split("/")[-1])
         else:
@@ -76,16 +66,6 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
             self._handle_run_all()
         elif path == "/api/refresh":
             self._serve_refresh()
-        else:
-            self._serve_404()
-
-    def do_DELETE(self):
-        parsed = urlparse(self.path)
-        path = parsed.path.rstrip("/") or "/"
-
-        if path.startswith("/api/history/"):
-            run_id = path.split("/")[-1]
-            self._handle_delete_history(run_id)
         else:
             self._serve_404()
 
@@ -117,35 +97,13 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
                     "nodeids": info["nodeids"],
                     "log_count": len(info["logs"]),
                     "exit_code": info.get("exit_code"),
-                    "started_at": info.get("started_at"),
                 }
-        self._serve_json({
-            "active": runs,
-            "active_count": state.active_run_count(),
-            "running": state.is_any_run_active(),
-        })
+        self._serve_json(runs)
 
     def _serve_refresh(self):
         state.clear_caches()
         cases = get_test_cases()
         self._serve_json({"refreshed": True, "count": len(cases)})
-
-    # ── history handlers ──
-
-    def _serve_history_list(self):
-        runs = list_archived_runs(state._scan_dir)
-        self._serve_json(runs)
-
-    def _serve_history_detail(self, run_id: str):
-        data = load_archived_run(state._scan_dir, run_id)
-        if data is None:
-            self._serve_404()
-            return
-        self._serve_json(data)
-
-    def _handle_delete_history(self, run_id: str):
-        ok = delete_archived_run(state._scan_dir, run_id)
-        self._serve_json({"deleted": ok, "run_id": run_id})
 
     def _serve_404(self):
         self.send_response(404)
@@ -165,32 +123,9 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
             self._serve_json({"error": "No test cases selected"})
             return
 
-        if state.is_any_run_active():
-            self._serve_json({"error": "有任务正在运行，请等待完成后再试"})
-            return
+        verbosity = body.get("verbosity", "normal")
 
-        verbosity = body.get("verbosity", "verbose")
         run_id = uuid.uuid4().hex[:8]
-        self._start_run_with_id(run_id, nodeids, verbosity)
-
-    def _handle_run_all(self):
-        cases = get_test_cases()
-        all_nodeids = [c["nodeid"] for c in cases if c.get("nodeid")]
-        if not all_nodeids:
-            self._serve_json({"error": "No test cases found"})
-            return
-
-        if state.is_any_run_active():
-            self._serve_json({"error": "有任务正在运行，请等待完成后再试"})
-            return
-
-        body = self._read_body()
-        verbosity = body.get("verbosity", "verbose")
-        run_id = uuid.uuid4().hex[:8]
-        self._start_run_with_id(run_id, all_nodeids, verbosity)
-
-    def _start_run_with_id(self, run_id: str, nodeids: list[str], verbosity: str = "verbose"):
-        """Start a run immediately (assumes concurrency check passed)."""
         log_queue: queue.Queue = queue.Queue()
 
         with _runs_lock:
@@ -200,16 +135,39 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
                 "logs": [],
                 "nodeids": nodeids,
                 "exit_code": None,
-                "started_at": __import__("time").time(),
             }
 
-        t = threading.Thread(
-            target=_execute_tests,
-            args=(run_id, nodeids, verbosity),
-            daemon=True,
-        )
+        t = threading.Thread(target=_execute_tests, args=(run_id, nodeids, verbosity), daemon=True)
         t.start()
-        self._serve_json({"run_id": run_id, "count": len(nodeids), "status": "running"})
+        self._serve_json({"run_id": run_id, "count": len(nodeids)})
+
+    def _handle_run_all(self):
+        cases = get_test_cases()
+        all_nodeids = [c["nodeid"] for c in cases if c.get("nodeid")]
+        if not all_nodeids:
+            self._serve_json({"error": "No test cases found"})
+            return
+
+        body = self._read_body()
+        verbosity = body.get("verbosity", "normal")
+        self._start_run(all_nodeids, verbosity)
+
+    def _start_run(self, nodeids: list[str], verbosity: str = "normal"):
+        run_id = uuid.uuid4().hex[:8]
+        log_queue: queue.Queue = queue.Queue()
+
+        with _runs_lock:
+            _active_runs[run_id] = {
+                "queue": log_queue,
+                "status": "running",
+                "logs": [],
+                "nodeids": nodeids,
+                "exit_code": None,
+            }
+
+        t = threading.Thread(target=_execute_tests, args=(run_id, nodeids, verbosity), daemon=True)
+        t.start()
+        self._serve_json({"run_id": run_id, "count": len(nodeids)})
 
     # ── SSE streaming ──
 
@@ -229,21 +187,23 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
 
         log_queue = run_info["queue"]
-        sent_count = 0
-
         with _runs_lock:
             existing = list(run_info["logs"])
 
         try:
-            for line in existing[sent_count:]:
-                self._sse_event({"line": line})
-                sent_count += 1
+            for start in range(0, len(existing), _SSE_BATCH_LINES):
+                self._sse_event({"lines": existing[start:start + _SSE_BATCH_LINES]})
 
             while True:
                 try:
                     line = log_queue.get(timeout=1)
-                    self._sse_event({"line": line})
-                    sent_count += 1
+                    lines = [line]
+                    while len(lines) < _SSE_BATCH_LINES:
+                        try:
+                            lines.append(log_queue.get_nowait())
+                        except queue.Empty:
+                            break
+                    self._sse_event({"lines": lines})
                 except queue.Empty:
                     with _runs_lock:
                         status = run_info["status"]


### PR DESCRIPTION
## Problem

When `lounger runner` streams verbose pytest API logs, the browser becomes unresponsive.
The CLI completes normally, but the web runner appends and scrolls one DOM node per log line.

## Changes

- Default the web runner to normal verbosity.
- Reserve `-s` output for full verbosity.
- Batch SSE log messages.
- Render logs with a virtual list while retaining the full run log for scrolling and copying.

## Verification

- Started `lounger runner`.
- Ran a 39-case API test file with large response logs.
- Verified the UI remained responsive.
- Verified scrolling loads earlier and later log content.